### PR TITLE
Add CODEOWNERS file to manage commit rights

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mangelajo @tpantelis @Oats87


### PR DESCRIPTION
Add a GitHub CODEOWNERS file to support disaggregating commit rights.
Allows the Committer process in the Community Membership docs to be
implemented.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>