### PR TITLE
Add Stephen Kitt to as Project Owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
-* @mangelajo @tpantelis @Oats87
-go.sum @skitt
-go.mod @skitt
+* @mangelajo @tpantelis @Oats87 @skitt
 /.github/workflows/ 	@mkolesnik
 /scripts/ 		@mkolesnik
 Makefile* 		@mkolesnik


### PR DESCRIPTION
Stephen was recently elected a Project Owner by the other SubM Project
Owners. He should be a CODEOWNER for all files in all repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>