### PR TITLE
Wrap parameter/return lists as expected by gofumpt

### DIFF
--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -63,7 +63,8 @@ func NewRemotePod(pod *v1.Pod, remoteCluster *remotecluster.RemoteCluster, objID
 }
 
 func NewRemoteNetworkPolicy(np *v1net.NetworkPolicy, remoteCluster *remotecluster.RemoteCluster,
-	objID string, existingPods map[string]*RemotePod) *RemoteNetworkPolicy {
+	objID string, existingPods map[string]*RemotePod,
+) *RemoteNetworkPolicy {
 	rnp := &RemoteNetworkPolicy{
 		Cluster:    remoteCluster,
 		Np:         np,

--- a/pkg/networkpolicy/networkpolicy_test.go
+++ b/pkg/networkpolicy/networkpolicy_test.go
@@ -308,7 +308,8 @@ func newDefaultRemotePolicyAndCluster() (*RemoteNetworkPolicy, *remotecluster.Re
 }
 
 func createRemotePolicyAndCluster(selectedPods, ingressPods, namespace,
-	clusterID string) (*RemoteNetworkPolicy, *remotecluster.RemoteCluster) {
+	clusterID string,
+) (*RemoteNetworkPolicy, *remotecluster.RemoteCluster) {
 	np := createPodSelectorNetworkPolicy(selectedPods, ingressPods, namespace)
 	rc1 := remotecluster.New(clusterID, fake.NewSimpleClientset())
 	rp := NewRemoteNetworkPolicy(np, rc1, remotecluster.ObjID(np.Namespace, np.Name, rc1.ClusterID, np.UID), nil)


### PR DESCRIPTION
This is required by golangci-lint 1.45.2; it all involves formatting
wrapped lists of parameters or return types.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
