### PR TITLE
Fix new markdownlint invalid link error

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -1,7 +1,7 @@
 # Building and testing
 
-[//]: <> This is a temporary README instructing how to test coastguard deployment manually.
-[//]: <> Changes will be made so that coastguard will be deployed in kind using e2e scripts.
+This is a temporary README instructing how to test coastguard deployment manually.
+Changes will be made so that coastguard will be deployed in kind using e2e scripts.
 
 This patch builds and packages coastguard locally. The built image then needs to be imported in cluster 1 of kind deployment.
 To do the same, follow below steps:


### PR DESCRIPTION
With the new version of markdownlint-cli, this fails with:

> MD053/link-image-reference-definitions Link and image reference
definitions should be needed [Unused link or image reference definition:
"//"]

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
