### PR TITLE
Use ENV vars instead of flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ UNIT_TEST_ARGS := test/e2e
 
 build: bin/coastguard-controller
 bin/coastguard-controller: vendor/modules.txt $(shell find pkg)
-	${SCRIPTS_DIR}/compile.sh $@ pkg/coastguard/main.go $(BUILD_ARGS)
+	${SCRIPTS_DIR}/compile.sh $@ pkg/coastguard/main.go
 
 include $(SHIPYARD_DIR)/Makefile.inc
 


### PR DESCRIPTION
Switch to using Shipyard's ENV vars instead of flags, much simpler to
understand.

Depends on https://github.com/submariner-io/shipyard/pull/890

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
