### PR TITLE
Add Grype vul scan config, ignore protobuf false+

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,12 @@
+---
+ignore:
+  # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
+  # https://github.com/anchore/grype/issues/558
+  - vulnerability: CVE-2015-5237
+    package:
+      name: google.golang.org/protobuf
+  # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
+  # https://github.com/anchore/grype/issues/633
+  - vulnerability: CVE-2021-22570
+    package:
+      name: google.golang.org/protobuf


### PR DESCRIPTION
The Grype vulnerability scanning is failing on this. See the pointers in the config for details about the false positive (it's in C, not Go).

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
