### PR TITLE
Enable jobs on merge queues

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -3,12 +3,14 @@ name: Branch Checks
 
 on:
   pull_request:
+  merge_group:
 
 permissions: {}
 
 jobs:
   target_devel:
     name: PR targets devel
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Check that the PR targets devel

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'CODEOWNERS'
       - 'CODEOWNERS.in'
+  merge_group:
+    paths:
+      - 'CODEOWNERS'
+      - 'CODEOWNERS.in'
 
 permissions: {}
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,12 +3,14 @@ name: Linting
 
 on:
   pull_request:
+  merge_group:
 
 permissions: {}
 
 jobs:
   apply-suggestions-commits:
     name: 'No "Apply suggestions from code review" Commits'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Get PR commits
@@ -32,6 +34,21 @@ jobs:
           pattern: '^(?!fixup!)'
           flags: 'i'
           error: 'Fixup commits should be squashed into the commits under review'
+
+  dco:
+    name: DCO
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@8673d84c368f480628607dbe21c88545811ef23a
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run DCO check
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
 
   gitlint:
     name: Commit Message(s)

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,6 +3,7 @@ name: Unit Tests
 
 on:
   pull_request:
+  merge_group:
   push:
     tags:
       - 'v**'


### PR DESCRIPTION
See
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
for details.

The target_devel and apply-suggestions-commits jobs are required, so
they need to run on merge group events, but their results are only
valid outside the merge queue, so they are ignored if the event isn't
a pull_request event.

The DCO app is required by the CNCF, but doesn't support merge queues
yet. Until it does, this restores the old DCO check for PRs, ignoring
it in merge queues; that way, we can require that, ensuring that PR
commits have a DCO, without blocking the merge queue.

(The general reasoning is that PR checks should verify everything
related to the commits themselves; merge queue checks should verify
everything that changes as a result of the position of the PR in the
queue, which doesn't include commit texts, so anything related to that
can be ignored in the merge queue if it's been checked in the PR.
GitHub doesn't support different requirements for PRs and merge queues
yet, so this needs to be handled by skipping irrelevant tests in merge
queues in the workflow configuration itself.)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
