### PR TITLE
Pass functions to Eventually

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -86,14 +86,14 @@ var _ = Describe("Coastguard Controller", func() {
 				// make sure the remote clusters declare themselves as started
 				// before we close the channel
 				for _, rc := range cgController.remoteClusters {
-					Eventually(rc.Stopped(), 5).Should(BeFalse())
+					Eventually(rc.Stopped, 5).Should(BeFalse())
 				}
 			}()
 
 			cgController.Run(stopChan)
 
 			for _, rc := range cgController.remoteClusters {
-				Eventually(rc.Stopped(), 5).Should(BeTrue())
+				Eventually(rc.Stopped, 5).Should(BeTrue())
 			}
 		})
 	})


### PR DESCRIPTION
Eventually takes a function, not the result of a function call, so

    Eventually(rc.Stopped(), 5)

should be

    Eventually(rc.Stopped, 5)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
